### PR TITLE
(hotfix) TS7053: Element implicitly has an  any  type

### DIFF
--- a/packages/generator/src/helpers/getExplicitlyTypedHandlersCode.ts
+++ b/packages/generator/src/helpers/getExplicitlyTypedHandlersCode.ts
@@ -60,10 +60,10 @@ export const getExplicitlyTypedHandlersCode =
 
     for (const { functionName, typeName } of handlersData) {
       result += `\n\n export const ${functionName} = (input: ${typeName}): ${typeName} => {
-        const result = {};
+        const result:Record<string, any> = {};
     
         ${getModelFieldsVariableName(model.name)}.forEach((key) => {
-          result[key] = input[key];
+          result[key] = (input as any)[key];
         })
     
         return result as ${typeName};

--- a/packages/generator/src/helpers/getImplicitlyTypedHandlerCode.ts
+++ b/packages/generator/src/helpers/getImplicitlyTypedHandlerCode.ts
@@ -3,10 +3,10 @@ import { getModelFieldsVariableName } from "./common/names"
 
 export const getImplicitlyTypedHandlerCode = (model: DMMF.Model) => {
   return `export const polish${model.name} = <T>(input: T): T => {
-      const result = {};
+      const result:Record<string, any> = {};
   
       ${getModelFieldsVariableName(model.name)}.forEach((key) => {
-        result[key] = input[key];
+        result[key] = (input as any)[key];
       })
   
       return result as T;


### PR DESCRIPTION
Specify some types to fix "TS7053: Element implicitly has an  any  type because expression of type  string  can't be used to index type  {}  No index signature with a parameter of type  string  was found on type  {} "